### PR TITLE
Add custom monitoring notification demo + sample hardening

### DIFF
--- a/BackgroundMonitoringSample/README.md
+++ b/BackgroundMonitoringSample/README.md
@@ -7,12 +7,24 @@
 ![SDK](https://img.shields.io/badge/sdk-2.0.0-red.svg)
 
 BackgroundMonitoringSample is an app demonstrating the OneStep core SDK collecting background sensor data and syncing it to produce background recording records.
+
+## Documentation
+
+📖 **[OneStep Collect for Android — full documentation](https://glorious-caboc-cd3.notion.site/onestep-collect-for-android)**
+
+That guide covers SDK setup, identity verification, the monitoring lifecycle (`enable` vs
+`optIn`/`optOut`), notification configuration, daily summaries, and the events stream. This sample
+links back to it from the relevant code.
+
+> `migration-guide-ios-developer.md` in this folder is a v1→v2 API reference aimed at **iOS**
+> developers porting from the Android SDK. Android consumers can ignore it.
+
 ## Features
 
 - Detecting movement.
 - Recording motion data as a background service.
 - Storing and analysing motion data.
-- Presenting the motion records by days, hours...
+- Presenting the recorded data as daily step summaries.
 
 ## Main functionality
 
@@ -21,7 +33,104 @@ BackgroundMonitoringSample is an app demonstrating the OneStep core SDK collecti
 
 - Records screen demonstrates how to fetch the records from the server and present them in a list.
 
+- Notification style picker on the Monitoring screen demonstrates the three ways to render the
+  foreground-service notification (see below). Picking a style updates the live notification
+  immediately and is remembered across app restarts.
+
 ![Alt text](https://github.com/OneStepRND/onestep-sdk-android-samples/blob/main/BackgroundMonitoringSample/backgroundTutorial.gif)
+
+## Monitoring lifecycle: `enable` vs opt-in
+
+These are two different things and a common point of confusion:
+
+- `monitoring.enable()` — wires up the monitoring subsystem for the session. Called once after
+  identification (see `BgMonitoringSampleApplication`). It does **not** start collecting by itself.
+- `monitoring.optIn()` / `monitoring.optOut()` — the user's consent toggle. `optIn()` actually
+  starts background collection (this sample calls it from `MainViewModel` once the runtime
+  permissions are granted); `optOut()` stops it. Observe `monitoring.preference` and
+  `monitoring.state` (a `OSTMonitoringRuntimeState` of `Active` / `Inactive` / `Blocked` / `Error`)
+  to drive your UI.
+
+## Permissions
+
+The host app requests two **runtime** permissions (see `MainScreen`): `ACTIVITY_RECOGNITION` and,
+on Android 13+, `POST_NOTIFICATIONS`. The SDK contributes the rest via manifest merging, so you do
+not declare them — but several are privacy-sensitive and **must be reflected in your Play Store Data
+safety form**, notably `RECORD_AUDIO` + `FOREGROUND_SERVICE_MICROPHONE` (audio-based motion sensing)
+and `ACCESS_FINE/COARSE_LOCATION`. See the commented list in `AndroidManifest.xml`, or open
+Android Studio → *Merged Manifest* for the authoritative set.
+
+## Customizing the monitoring notification
+
+Background monitoring runs in a foreground service, so Android requires an ongoing notification
+while it is active. You control its appearance through a single SDK entry point:
+
+```kotlin
+monitoring.setCustomMonitoringNotification {
+    // call exactly one of: default(...) / custom(...) / native(...)
+}
+```
+
+`setCustomMonitoringNotification` **persists** the config but does not refresh a notification that
+is already showing — the foreground service only rebuilds it from the persisted config the next
+time it (re)starts. So:
+
+- Call it **before** opting in, so the first notification already uses your config. This sample
+  re-applies the user's last choice at startup (`BgMonitoringSampleApplication`).
+- To change the style while monitoring is **active** (as the in-app picker does), the sample sends
+  the always-on service its `ACTION_UPDATE_NOTIFICATION` command, which makes it rebuild the live
+  notification immediately. (`optOut()`/`optIn()` do **not** reliably rebuild it.)
+
+The selected style is persisted in `SharedPreferences`, so the picker and the live notification stay
+in sync across app restarts.
+
+There are three styles, each backed by an `OSTNotificationConfig`. This sample builds all three in
+[`MonitoringNotifications`](app/src/main/java/com/onestep/backgroundmonitoringsample/notifications/MonitoringNotifications.kt)
+and lets you switch between them from the Monitoring screen.
+
+**1. Default** — the SDK renders a simple title/text notification. `title`/`text` are lambdas so
+the SDK can re-evaluate them (e.g. for localization) whenever it rebuilds the notification.
+
+```kotlin
+monitoring.setCustomMonitoringNotification {
+    default(
+        icon = R.drawable.ic_launcher_foreground,
+        title = { "Background Monitoring Sample is active" },
+        text = { "OneStep is tracking your movement in the background" },
+    )
+}
+```
+
+**2. Custom** — the SDK renders a richer notification showing your app name and live progress
+toward a daily step goal. The SDK fills in the current step count for you.
+
+```kotlin
+monitoring.setCustomMonitoringNotification {
+    custom(
+        appName = "Background Monitoring Sample",
+        stepsGoal = 8_000,
+        icon = R.drawable.ic_launcher_foreground,
+    )
+}
+```
+
+**3. Native** — you build the entire `android.app.Notification` and hand it to the SDK. Use this
+when you need full control (custom layouts, actions, styles). You own the notification channel, so
+create it before building. The `icon` argument is the small icon the foreground service falls back
+to.
+
+```kotlin
+monitoring.setCustomMonitoringNotification {
+    native(
+        notification = NotificationCompat.Builder(context, YOUR_CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle("OneStep is recording")
+            .setOngoing(true)
+            .build(),
+        icon = R.drawable.ic_launcher_foreground,
+    )
+}
+```
 
 ### Requirements
 
@@ -29,21 +138,49 @@ BackgroundMonitoringSample is an app demonstrating the OneStep core SDK collecti
 |---|---|
 | Android API (min) | 26 |
 | Android API (target / compile) | 35 |
-| Android Gradle Plugin | 9.0.0 |
-| Kotlin | 2.2.10 |
-| Compose BOM | 2024.09.02 |
+| Android Gradle Plugin | 8.12.3 |
+| Kotlin | 2.0.21 |
+| Compose BOM | 2024.08.00 |
 | OneStep SDK (core) | 2.0.0 |
 
-Toolchain versions mirror `UiKitSample/gradle/libs.versions.toml`, the canonical reference for sample apps in this repo.
+These values come from this module's `gradle/libs.versions.toml` — the source of truth for what
+builds. Update both together if you bump versions.
 
 ### Installation
 
-Clone this repo or download the code, run the app in Android studio or your choice of IDE
-Make sure you run this sample app on an actual device to use the motion sensors and get actual background record and analysis.
+1. Clone this repo (or download the code) and open this module in Android Studio.
+2. **Add your credentials to `local.properties` first** (see [Keys](#keys)) — without them the SDK
+   fails to connect and the app shows "SDK session lost".
+3. Run on a **physical device** — the emulator has no motion sensors, so you won't get real
+   background records or analysis.
 
 ### Keys
 
-To initilize this app you need to obtain specific API-KEY, reach out to `shahar@onestep.co` for more details and access to the SDK.
+To initialize this app you need a OneStep client token (and optionally an identity-verification
+secret). Reach out to `shahar@onestep.co` for access to the SDK and credentials.
+
+Credentials are **never stored in source**. They are read from `local.properties` (which is
+gitignored) and exposed to the app through `BuildConfig` at build time. Add these lines to
+`local.properties`:
+
+```properties
+onestep.clientToken=<YOUR-CLIENT-TOKEN>
+onestep.customerPatientId=<A-STABLE-ID-FOR-THE-CURRENT-USER>
+# Precomputed identity-verification digest (leave blank to skip identity verification):
+onestep.identityVerification=<HMAC-DIGEST>
+```
+
+**Identity verification.** `onestep.identityVerification` is **not** the secret — it is the
+hex-encoded `HMAC_SHA256(key = <identity-verification secret>, message = <customerPatientId>)`.
+The secret must stay on your server; production apps should fetch the precomputed digest from a
+backend and never embed the secret. For local testing you can compute the digest with:
+
+```bash
+printf '%s' "<customerPatientId>" | openssl dgst -sha256 -hmac "<SECRET>" -hex
+```
+
+Recompute the digest whenever you change `onestep.customerPatientId`, since the digest is bound to
+that id. If the digest is wrong, the SDK fails to connect with HTTP 403 `invalid hmac_digest`.
 
 ## Support
 

--- a/BackgroundMonitoringSample/app/build.gradle.kts
+++ b/BackgroundMonitoringSample/app/build.gradle.kts
@@ -1,8 +1,18 @@
+import java.util.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.compose.compiler)
 }
+
+// Load OneStep credentials from the gitignored local.properties so no keys live in source.
+// Missing keys fall back to empty strings, so the project still compiles on a fresh clone.
+val localProperties = Properties().apply {
+    val file = rootProject.file("local.properties")
+    if (file.exists()) file.inputStream().use { load(it) }
+}
+fun localProperty(key: String): String = localProperties.getProperty(key, "")
 
 android {
     namespace = "com.onestep.backgroundmonitoringsample"
@@ -19,6 +29,11 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        // OneStep credentials sourced from local.properties (never committed).
+        buildConfigField("String", "ONESTEP_CLIENT_TOKEN", "\"${localProperty("onestep.clientToken")}\"")
+        buildConfigField("String", "ONESTEP_CUSTOMER_PATIENT_ID", "\"${localProperty("onestep.customerPatientId")}\"")
+        buildConfigField("String", "ONESTEP_IDENTITY_VERIFICATION", "\"${localProperty("onestep.identityVerification")}\"")
     }
 
     buildTypes {
@@ -39,6 +54,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.1"

--- a/BackgroundMonitoringSample/app/proguard-rules.pro
+++ b/BackgroundMonitoringSample/app/proguard-rules.pro
@@ -20,10 +20,8 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
-# - OneStepSDK
--keep class co.onestep.android.core.** { *; }
--keep interface co.onestep.android.core.** { *; }
--keepattributes *Annotation*
--keepclassmembernames class * {
-    public void log*(...);
-}
+# --- OneStep SDK ---
+# No app-side keep rules are needed: the OneStep SDK AAR ships its own *consumer* ProGuard rules,
+# which R8 applies automatically. Do NOT add a blanket `-keep class co.onestep.android.core.** { *; }`
+# — it disables R8 optimization/shrinking for the whole SDK and bloats your APK. If a release build
+# ever fails, add the narrowest keep for the specific class R8 reports, not a package wildcard.

--- a/BackgroundMonitoringSample/app/src/main/AndroidManifest.xml
+++ b/BackgroundMonitoringSample/app/src/main/AndroidManifest.xml
@@ -2,7 +2,26 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.CAMERA" />
+    <!--
+        Runtime ("dangerous") permissions the host app must request at runtime (see MainScreen).
+        ACTIVITY_RECOGNITION is required for step/movement detection; POST_NOTIFICATIONS (API 33+)
+        is required to show the foreground-service notification.
+    -->
+    <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <!--
+        The OneStep SDK contributes the rest of its required permissions via manifest merging, so
+        you do NOT need to declare them yourself. They are listed here for awareness because some
+        are privacy-sensitive and must be reflected in your Play Store Data safety form:
+          • FOREGROUND_SERVICE, FOREGROUND_SERVICE_HEALTH  – the always-on monitoring service
+          • FOREGROUND_SERVICE_MICROPHONE, RECORD_AUDIO    – audio-based motion sensing
+          • ACCESS_FINE_LOCATION, ACCESS_COARSE_LOCATION   – location context
+          • INTERNET, ACCESS_NETWORK_STATE                 – syncing data
+          • RECEIVE_BOOT_COMPLETED                         – restart monitoring after reboot
+          • REQUEST_IGNORE_BATTERY_OPTIMIZATIONS, WAKE_LOCK – background reliability
+        Inspect the merged manifest (Android Studio → Merged Manifest) for the authoritative list.
+    -->
 
     <application
         android:allowBackup="true"

--- a/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/BgMonitoringSampleApplication.kt
+++ b/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/BgMonitoringSampleApplication.kt
@@ -8,6 +8,7 @@ import co.onestep.android.core.monitoring.getMonitoring
 import co.onestep.android.core.onError
 import co.onestep.android.core.onSuccess
 import com.onestep.backgroundmonitoringsample.analytics.EventsCollector
+import com.onestep.backgroundmonitoringsample.notifications.MonitoringNotifications
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -41,24 +42,28 @@ class BgMonitoringSampleApplication : Application() {
     }
 
     private suspend fun identifyAndStartMonitoring(oneStep: OneStep) {
-        // Step 2: Identify user
+        // Step 2: Identify user. Credentials come from local.properties via BuildConfig, so no
+        // keys live in source. identityVerification is the precomputed HMAC digest (or blank);
+        // pass null when blank to connect without identity verification.
         oneStep.setPatient(
-            apiKey = "<YOUR-CLIENT-TOKEN-HERE>",
-            customerPatientId = "<A-UUID-FOR-CURRENT-USER-HERE>",
-            identityVerification = null, // <YOUR-IDENTITY-VERIFICATION-SECRET-HERE>
+            apiKey = BuildConfig.ONESTEP_CLIENT_TOKEN,
+            customerPatientId = BuildConfig.ONESTEP_CUSTOMER_PATIENT_ID,
+            identityVerification = BuildConfig.ONESTEP_IDENTITY_VERIFICATION.ifBlank { null },
         ).onSuccess {
             Log.d(TAG, "SDK identified successfully")
             val monitoring = oneStep.getMonitoring().getOr(null) ?: return@onSuccess
-            // Step 3: Initialize monitoring
+            // Step 3: Enable monitoring. enable() wires up the monitoring subsystem for this
+            // session; it does NOT start collecting on its own. The user must then OPT IN
+            // (monitoring.optIn(), called from MainViewModel after permissions are granted) to
+            // actually begin background collection, and can optOut() to stop. Think of it as:
+            // enable = "make the feature available", optIn/optOut = "the user's consent toggle".
+            // Docs: https://glorious-caboc-cd3.notion.site/onestep-collect-for-android
             monitoring.enable()
-            // Step 4: Set notification
-            monitoring.setCustomMonitoringNotification {
-                default(
-                    icon = R.drawable.ic_launcher_foreground,
-                    title = { "This is the Sample App monitoring" },
-                    text = null,
-                )
-            }
+            // Step 4: Set the foreground-service notification. We re-apply the user's last choice
+            // (default on first run) so the live notification matches the in-app picker after an
+            // app restart. All three styles are built in MonitoringNotifications so the startup and
+            // in-app paths stay in sync.
+            MonitoringNotifications.apply(monitoring, this, MonitoringNotifications.savedStyle(this))
         }.onError { error ->
             Log.e(TAG, "SDK setPatient failed: ${error.cause.message}")
         }

--- a/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/analytics/SampleAnalytics.kt
+++ b/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/analytics/SampleAnalytics.kt
@@ -5,6 +5,14 @@ import co.onestep.android.core.OneStep
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
+/**
+ * The SDK emits lifecycle/telemetry events on the cold [OneStep.events] flow (identification,
+ * monitoring state changes, sync results, errors, …). Collect it once from an
+ * application-scoped coroutine. This sample just logs each event; a real app would typically
+ * forward them to its own analytics pipeline and/or react to specific event names.
+ *
+ * Docs: https://glorious-caboc-cd3.notion.site/onestep-collect-for-android
+ */
 object EventsCollector {
     private const val TAG = "OneStepEvents"
 

--- a/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/notifications/MonitoringNotifications.kt
+++ b/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/notifications/MonitoringNotifications.kt
@@ -1,0 +1,167 @@
+package com.onestep.backgroundmonitoringsample.notifications
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import co.onestep.android.core.OSTResult
+import co.onestep.android.core.monitoring.OSTMonitoring
+import com.onestep.backgroundmonitoringsample.R
+import com.onestep.backgroundmonitoringsample.ui.model.NotificationStyle
+
+/**
+ * Background monitoring runs inside an Android *foreground service*, so the OS requires it to
+ * show an ongoing notification for as long as it is active. The OneStep SDK lets you control how
+ * that notification looks through a single entry point:
+ *
+ * ```
+ * monitoring.setCustomMonitoringNotification { /* OSTNotificationConfigScope */ }
+ * ```
+ *
+ * Inside the lambda you call exactly one of three builders, each producing a different
+ * [co.onestep.android.core.monitoring.OSTNotificationConfig]:
+ *
+ *  - [default] — the SDK renders a simple title/text notification for you.
+ *  - [custom]  — the SDK renders a richer notification showing your app name and live progress
+ *                toward a daily step goal.
+ *  - [native]  — you build a fully custom [android.app.Notification] and hand it to the SDK.
+ *
+ * `setCustomMonitoringNotification` can be called at any time, including while monitoring is
+ * already active — the live foreground-service notification updates in place. This object is the
+ * single place this sample builds those configs so the call sites (startup + the in-app picker)
+ * stay in sync.
+ */
+object MonitoringNotifications {
+
+    /** Small icon shown in the status bar for every style. Must be a valid drawable resource. */
+    private val NOTIFICATION_ICON = R.drawable.ic_launcher_foreground
+
+    private const val APP_NAME = "Background Monitoring Sample"
+
+    /** Step goal surfaced by the [NotificationStyle.CUSTOM] progress notification. */
+    private const val DAILY_STEPS_GOAL = 8_000
+
+    /**
+     * Notification channel used only by the [NotificationStyle.NATIVE] example. The SDK manages
+     * its own channel for the [NotificationStyle.DEFAULT] / [NotificationStyle.CUSTOM] styles; for
+     * a native notification *you* own the channel, so we create it before building.
+     */
+    private const val NATIVE_CHANNEL_ID = "onestep_sample_native_monitoring"
+
+    private const val PREFS_NAME = "onestep_sample_prefs"
+    private const val KEY_STYLE = "notification_style"
+
+    // SDK-internal foreground service + command used to refresh the live notification. The SDK
+    // already rebuilds the notification from the persisted config when it receives this action;
+    // setCustomMonitoringNotification itself does NOT trigger it, so we send it ourselves.
+    private const val ALWAYS_ON_SERVICE_FQN =
+        "co.onestep.android.core.monitoring.background.OSTAlwaysOnForegroundService"
+    private const val ACTION_UPDATE_NOTIFICATION = "ACTION_UPDATE_NOTIFICATION"
+
+    /** The notification style the user last selected, persisted across app restarts. */
+    fun savedStyle(context: Context): NotificationStyle {
+        val name = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .getString(KEY_STYLE, null)
+        return NotificationStyle.entries.firstOrNull { it.name == name } ?: NotificationStyle.DEFAULT
+    }
+
+    /**
+     * Applies [style] to the SDK's foreground-service notification and remembers the choice.
+     *
+     * Note: the SDK only *persists* the config here — it does not refresh a notification that is
+     * already showing. Call [refreshLiveNotification] afterwards to apply it to the live one.
+     *
+     * @return [OSTResult.Success] when the SDK accepted the config, otherwise [OSTResult.Failure].
+     */
+    fun apply(
+        monitoring: OSTMonitoring,
+        context: Context,
+        style: NotificationStyle,
+    ): OSTResult<Unit> {
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            .edit()
+            .putString(KEY_STYLE, style.name)
+            .apply()
+        return setNotificationConfig(monitoring, context, style)
+    }
+
+    /**
+     * Forces the running always-on service to rebuild the live notification from the config just
+     * applied. No-op safe to call when the service is running; only call this while monitoring is
+     * active (otherwise it would start the service for a user who has opted out).
+     */
+    fun refreshLiveNotification(context: Context) {
+        val intent = Intent()
+            .setComponent(ComponentName(context.packageName, ALWAYS_ON_SERVICE_FQN))
+            .setAction(ACTION_UPDATE_NOTIFICATION)
+        ContextCompat.startForegroundService(context, intent)
+    }
+
+    private fun setNotificationConfig(
+        monitoring: OSTMonitoring,
+        context: Context,
+        style: NotificationStyle,
+    ): OSTResult<Unit> = monitoring.setCustomMonitoringNotification {
+        when (style) {
+            // Style 1 — DEFAULT: the SDK renders the notification. Title/text are lambdas so they
+            // can be re-evaluated by the SDK (e.g. for localization) each time it rebuilds.
+            NotificationStyle.DEFAULT -> default(
+                icon = NOTIFICATION_ICON,
+                title = { "$APP_NAME is active" },
+                text = { "OneStep is tracking your movement in the background" },
+            )
+
+            // Style 2 — CUSTOM: the SDK renders a richer notification with your app name and a
+            // live progress bar toward `stepsGoal`. The SDK fills in the current step count.
+            NotificationStyle.CUSTOM -> custom(
+                appName = APP_NAME,
+                stepsGoal = DAILY_STEPS_GOAL,
+                icon = NOTIFICATION_ICON,
+            )
+
+            // Style 3 — NATIVE: you build the entire android.app.Notification. Use this when you
+            // need full control (custom layouts, actions, styles). The `icon` argument is the
+            // small icon the foreground service falls back to.
+            NotificationStyle.NATIVE -> native(
+                notification = buildNativeNotification(context.applicationContext),
+                icon = NOTIFICATION_ICON,
+            )
+        }
+    }
+
+    /**
+     * Builds a fully custom foreground-service notification for [NotificationStyle.NATIVE].
+     *
+     * A foreground-service notification must use a channel that already exists, so we create the
+     * channel first. minSdk for this sample is 26, where notification channels are always present.
+     */
+    private fun buildNativeNotification(context: Context): Notification {
+        ensureNativeChannel(context)
+        return NotificationCompat.Builder(context, NATIVE_CHANNEL_ID)
+            .setSmallIcon(NOTIFICATION_ICON)
+            .setContentTitle("OneStep is recording 🏃")
+            .setContentText("Fully custom notification built by the host app")
+            .setOngoing(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+    }
+
+    private fun ensureNativeChannel(context: Context) {
+        val manager = context.getSystemService(NotificationManager::class.java)
+        if (manager.getNotificationChannel(NATIVE_CHANNEL_ID) == null) {
+            manager.createNotificationChannel(
+                NotificationChannel(
+                    NATIVE_CHANNEL_ID,
+                    "Background Monitoring (Native)",
+                    NotificationManager.IMPORTANCE_LOW,
+                ).apply {
+                    description = "Foreground-service notification built by the sample app"
+                },
+            )
+        }
+    }
+}

--- a/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/screens/MainScreen.kt
+++ b/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/screens/MainScreen.kt
@@ -24,6 +24,7 @@ import com.onestep.backgroundmonitoringsample.viewmodels.MainViewModel
 @OptIn(ExperimentalPermissionsApi::class)
 fun MainScreen(viewModel: MainViewModel) {
     val monitoringState = viewModel.monitoringUiState.collectAsState()
+    val notificationStyle = viewModel.notificationStyle.collectAsState()
     val screenState = viewModel.screenState
 
     // Permission for activity recognition is required to use the SDK
@@ -75,15 +76,23 @@ fun MainScreen(viewModel: MainViewModel) {
             is ScreenState.Initialized -> {
                 MonitoringScreen(
                     monitoringState = monitoringState.value,
+                    notificationStyle = notificationStyle.value,
                     onOptIn = { viewModel.optInToMonitoring() },
                     onOptOut = { viewModel.optOutOfMonitoring() },
+                    onSelectNotificationStyle = { style ->
+                        viewModel.setNotificationStyle(style)
+                    },
                     onShowRecords = {
                         viewModel.setState(ScreenState.Records)
                     },
                 )
             }
 
-            is ScreenState.Records -> RecordsListScreen()
+            is ScreenState.Records -> {
+                val records = viewModel.records.collectAsState()
+                LaunchedEffect(Unit) { viewModel.loadRecords() }
+                RecordsListScreen(items = records.value)
+            }
         }
     }
 }

--- a/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/screens/MonitoringScreen.kt
+++ b/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/screens/MonitoringScreen.kt
@@ -4,12 +4,15 @@ import android.widget.Toast
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.selection.selectable
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Create
@@ -18,14 +21,17 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.CenterHorizontally
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import co.onestep.android.core.OneStep
@@ -34,13 +40,16 @@ import co.onestep.android.core.monitoring.OSTMonitoringPreference
 import co.onestep.android.core.monitoring.OSTMonitoringRuntimeState
 import com.onestep.backgroundmonitoringsample.components.SafeSDKButton
 import com.onestep.backgroundmonitoringsample.ui.model.MonitoringUiState
+import com.onestep.backgroundmonitoringsample.ui.model.NotificationStyle
 import kotlinx.coroutines.launch
 
 @Composable
 fun MonitoringScreen(
     monitoringState: MonitoringUiState,
+    notificationStyle: NotificationStyle,
     onOptIn: () -> Unit,
     onOptOut: () -> Unit,
+    onSelectNotificationStyle: (NotificationStyle) -> Unit,
     onShowRecords: () -> Unit,
 ) {
     val context = LocalContext.current
@@ -80,6 +89,13 @@ fun MonitoringScreen(
                 color = Color(0xFF4678B4),
             )
         }
+        Spacer(modifier = Modifier.height(32.dp))
+        HorizontalDivider(color = Color.Gray, modifier = Modifier.padding(vertical = 8.dp))
+        Spacer(modifier = Modifier.height(16.dp))
+        NotificationStyleSection(
+            selected = notificationStyle,
+            onSelect = onSelectNotificationStyle,
+        )
         Spacer(modifier = Modifier.height(32.dp))
         HorizontalDivider(color = Color.Gray, modifier = Modifier.padding(vertical = 8.dp))
         Spacer(modifier = Modifier.height(32.dp))
@@ -133,4 +149,84 @@ private fun ScreenTitle(
                 .then(modifier),
         )
     }
+}
+
+/**
+ * Lets the user switch the foreground-service notification style at runtime. Selecting an option
+ * calls back into the SDK via the ViewModel; if monitoring is active the live notification updates
+ * in place. Demonstrates the three OSTNotificationConfigScope builders (default / custom / native).
+ */
+@Composable
+private fun NotificationStyleSection(
+    selected: NotificationStyle,
+    onSelect: (NotificationStyle) -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxWidth()) {
+        ScreenTitle(text = "Notification Style")
+        Text(
+            text = "How the ongoing background-monitoring notification is rendered.",
+            fontSize = 14.sp,
+            color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        NotificationStyle.entries.forEach { style ->
+            NotificationStyleOption(
+                style = style,
+                isSelected = style == selected,
+                onSelect = { onSelect(style) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun NotificationStyleOption(
+    style: NotificationStyle,
+    isSelected: Boolean,
+    onSelect: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .selectable(selected = isSelected, onClick = onSelect)
+            .padding(vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        RadioButton(selected = isSelected, onClick = onSelect)
+        Spacer(modifier = Modifier.width(8.dp))
+        Column {
+            Text(
+                text = style.label,
+                fontSize = 16.sp,
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            Text(
+                text = style.description,
+                fontSize = 13.sp,
+                color = MaterialTheme.colorScheme.onBackground.copy(alpha = 0.7f),
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MonitoringScreenPreview() {
+    MonitoringScreen(
+        monitoringState = MonitoringUiState(),
+        notificationStyle = NotificationStyle.DEFAULT,
+        onOptIn = {},
+        onOptOut = {},
+        onSelectNotificationStyle = {},
+        onShowRecords = {},
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun NotificationStyleSectionPreview() {
+    NotificationStyleSection(
+        selected = NotificationStyle.CUSTOM,
+        onSelect = {},
+    )
 }

--- a/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/screens/RecordsListScreen.kt
+++ b/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/screens/RecordsListScreen.kt
@@ -11,34 +11,17 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import co.onestep.android.core.OneStep
-import co.onestep.android.core.getOr
-import co.onestep.android.core.monitoring.getMonitoring
 import com.onestep.backgroundmonitoringsample.ui.model.ActivityItem
 import com.onestep.backgroundmonitoringsample.ui.model.ActivityItemUI
 
 @Composable
-fun RecordsListScreen() {
-    var items by remember { mutableStateOf(emptyList<ActivityItem>()) }
-
-    LaunchedEffect(Unit) {
-        val oneStep = OneStep.getInstance().getOr(null) ?: return@LaunchedEffect
-        val monitoring = oneStep.getMonitoring().getOr(null) ?: return@LaunchedEffect
-        items = monitoring.getDailySummaries().getOr(emptyList())
-            .map(ActivityItem::fromDailySummary)
-            .sortedByDescending { it.startTime }
-    }
-
+fun RecordsListScreen(items: List<ActivityItem>) {
     if (items.isEmpty()) {
         Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
             Text(text = "Your care log is empty")
@@ -63,4 +46,19 @@ fun RecordsListScreen() {
             items(items) { ActivityItemUI(activityItem = it) }
         }
     }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun RecordsListScreenPreview() {
+    RecordsListScreen(
+        items = listOf(
+            ActivityItem(
+                uuid = "1",
+                title = "2026-06-22 - 5,231 steps",
+                startTime = "2026-06-22",
+                details = mapOf("Date" to "2026-06-22", "Total Steps" to "5231"),
+            ),
+        ),
+    )
 }

--- a/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/ui/model/NotificationStyle.kt
+++ b/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/ui/model/NotificationStyle.kt
@@ -1,0 +1,26 @@
+package com.onestep.backgroundmonitoringsample.ui.model
+
+/**
+ * The three foreground-service notification styles the OneStep SDK supports, surfaced in the UI so
+ * consumers can switch between them at runtime and see the result live. Each entry maps to one
+ * builder on the SDK's `OSTNotificationConfigScope` (see `MonitoringNotifications`).
+ *
+ * Enums are a stable Compose type, so this can be passed straight into composables.
+ */
+enum class NotificationStyle(
+    val label: String,
+    val description: String,
+) {
+    DEFAULT(
+        label = "Default",
+        description = "SDK-rendered title and text.",
+    ),
+    CUSTOM(
+        label = "Custom",
+        description = "SDK-rendered app name with live progress toward a step goal.",
+    ),
+    NATIVE(
+        label = "Native",
+        description = "A fully custom android.app.Notification built by this app.",
+    ),
+}

--- a/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/viewmodels/MainViewModel.kt
+++ b/BackgroundMonitoringSample/app/src/main/java/com/onestep/backgroundmonitoringsample/viewmodels/MainViewModel.kt
@@ -1,22 +1,30 @@
 package com.onestep.backgroundmonitoringsample.viewmodels
 
+import android.app.Application
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
-import androidx.lifecycle.ViewModel
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import co.onestep.android.core.OSTIdentificationState
 import co.onestep.android.core.OneStep
 import co.onestep.android.core.getOr
+import co.onestep.android.core.monitoring.OSTMonitoringRuntimeState
+import co.onestep.android.core.monitoring.OSTSortOrder
 import co.onestep.android.core.monitoring.getMonitoring
+import co.onestep.android.core.onSuccess
+import com.onestep.backgroundmonitoringsample.notifications.MonitoringNotifications
+import com.onestep.backgroundmonitoringsample.ui.model.ActivityItem
 import com.onestep.backgroundmonitoringsample.ui.model.MonitoringUiState
+import com.onestep.backgroundmonitoringsample.ui.model.NotificationStyle
 import com.onestep.backgroundmonitoringsample.ui.model.ScreenState
+import java.time.LocalDate
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
-class MainViewModel : ViewModel() {
+class MainViewModel(app: Application) : AndroidViewModel(app) {
 
     // The SDK is initialised in BgMonitoringSampleApplication.onCreate(), so by the
     // time this ViewModel is constructed the process-singleton handle is available.
@@ -28,8 +36,60 @@ class MainViewModel : ViewModel() {
     private val _monitoringUiState = MutableStateFlow(MonitoringUiState())
     val monitoringUiState: StateFlow<MonitoringUiState> = _monitoringUiState
 
+    // The selected notification style is host-app state (not reported by the SDK), so it is kept
+    // separate from the SDK-driven monitoringUiState. It is seeded from the persisted choice so
+    // the picker reflects what is actually applied after an app restart.
+    private val _notificationStyle =
+        MutableStateFlow(MonitoringNotifications.savedStyle(getApplication()))
+    val notificationStyle: StateFlow<NotificationStyle> = _notificationStyle
+
+    // Daily step summaries shown on the Records screen. Loaded through the ViewModel (rather than
+    // the screen reaching into the SDK directly) so all SDK access stays in one place.
+    private val _records = MutableStateFlow<List<ActivityItem>>(emptyList())
+    val records: StateFlow<List<ActivityItem>> = _records
+
     fun setState(state: ScreenState) {
         screenState = state
+    }
+
+    /**
+     * Loads daily summaries via [co.onestep.android.core.monitoring.OSTMonitoring.getDailySummaries].
+     * The query is a DSL: set [from]/[to] (java.time.LocalDate), [order], and [maxDays] to scope it.
+     * Here we ask for the last 30 days, newest first. Call getDailySummaries() with no block for the
+     * SDK defaults.
+     * Docs: https://glorious-caboc-cd3.notion.site/onestep-collect-for-android
+     */
+    fun loadRecords() {
+        viewModelScope.launch {
+            val monitoring = oneStep.getMonitoring().getOr(null) ?: return@launch
+            val summaries = monitoring.getDailySummaries {
+                from = LocalDate.now().minusDays(30)
+                to = LocalDate.now()
+                order = OSTSortOrder.DESC
+            }.getOr(emptyList())
+            _records.value = summaries
+                .map(ActivityItem::fromDailySummary)
+                .sortedByDescending { it.startTime }
+        }
+    }
+
+    /**
+     * Switches the foreground-service notification style at runtime. setCustomMonitoringNotification
+     * only persists the config, so when monitoring is active we ask the running service to rebuild
+     * the live notification. The choice is persisted (in [MonitoringNotifications.apply]) and the UI
+     * reflects it once the SDK confirms it accepted the config.
+     */
+    fun setNotificationStyle(style: NotificationStyle) {
+        viewModelScope.launch {
+            val monitoring = oneStep.getMonitoring().getOr(null) ?: return@launch
+            MonitoringNotifications.apply(monitoring, getApplication(), style)
+                .onSuccess {
+                    _notificationStyle.value = style
+                    if (monitoring.state.value is OSTMonitoringRuntimeState.Active) {
+                        MonitoringNotifications.refreshLiveNotification(getApplication())
+                    }
+                }
+        }
     }
 
     fun start() {

--- a/BackgroundMonitoringSample/gradle/libs.versions.toml
+++ b/BackgroundMonitoringSample/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ espressoCore = "3.6.1"
 lifecycleRuntimeKtx = "2.8.4"
 activityCompose = "1.9.1"
 composeBom = "2024.08.00"
-oneStepSDK = "2.0.0-RC1"
+oneStepSDK = "2.0.0"
 androidxLifecycle = "2.8.4"
 accompanist = "0.34.0"
 


### PR DESCRIPTION
Notification feature:
- Demonstrate all three OSTNotificationConfig styles (default/custom/native) via a runtime picker on the Monitoring screen, built in MonitoringNotifications.
- Switching applies live (sends the always-on service ACTION_UPDATE_NOTIFICATION, since setCustomMonitoringNotification only persists the config) and the choice is persisted in SharedPreferences and re-applied at startup.

Credentials & identity verification:
- Move clientToken / customerPatientId / identityVerification out of source into gitignored local.properties, surfaced via BuildConfig.
- identityVerification is the precomputed HMAC-SHA256 digest (not the secret), fixing the HTTP 403 invalid_hmac_digest connect failure.

Sample review fixes:
- Manifest: drop stray CAMERA, declare the runtime-requested permissions, and document the SDK's merged permission footprint.
- proguard-rules: remove the over-broad SDK keep (SDK ships consumer rules).
- Route the Records screen through MainViewModel; demonstrate the getDailySummaries date-range query DSL.
- README: add Documentation links, monitoring lifecycle and permissions sections, fix version table; clarify enable() vs opt-in.
- Bump SDK to a resolvable 2.0.0.